### PR TITLE
Fix homing-override, gcode offset and position endstop

### DIFF
--- a/examples/easy-additions/homing.cfg
+++ b/examples/easy-additions/homing.cfg
@@ -25,7 +25,6 @@ gcode:
     ENTER_DOCKING_MODE
     SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0
     {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
-    {% set position_endstop_y = printer.configfile.config["stepper_y"]["position_endstop"]|float %}
     {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
     {% set home_all = 'X' not in params and 'Y' not in params and 'Z' not in params %}
 
@@ -41,6 +40,7 @@ gcode:
     {% endif %}
 
     {% if home_all or 'Y' in params or 'X' in params %}
+      {% set position_endstop_y = printer.configfile.config["stepper_y"]["position_endstop"]|float %}
       {% if config.sensorless_y %}
         _SENSORLESS_HOME AXIS=Y
       {% else %}

--- a/examples/easy-additions/homing.cfg
+++ b/examples/easy-additions/homing.cfg
@@ -22,8 +22,10 @@ gcode:
   {% if uses_tool_probe and printer.probe.last_query %}
     RESPOND TYPE=error MSG='Z Probe triggered, cannot home.'
   {% else %}
+    ENTER_DOCKING_MODE
     SET_GCODE_OFFSET X=0.0 Y=0.0 Z=0.0
     {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set position_endstop_y = printer.configfile.config["stepper_y"]["position_endstop"]|float %}
     {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
     {% set home_all = 'X' not in params and 'Y' not in params and 'Z' not in params %}
 
@@ -44,17 +46,20 @@ gcode:
       {% else %}
         G28 Y
       {% endif %}
-      G0 Y{ max_y - config.homing_rebound_y } F6000
+      G0 Y{ position_endstop_y - config.homing_rebound_y } F6000
     {% endif %}
 
     {% if home_all or 'X' in params %}
+      {% set position_endstop_x = printer.configfile.config["stepper_x"]["position_endstop"]|float %}
       {% if config.sensorless_x %}
         _SENSORLESS_HOME AXIS=X
       {% else %}
         G28 X
       {% endif %}
-      G0 X{ max_x - 10} F6000
+      G0 X{ position_endstop_x - 10} F6000
     {% endif %}
+
+    EXIT_DOCKING_MODE
 
     {% if home_all or 'Z' in params %}
       {% set random_x = (range(-50, 50) | random) / 10 %}


### PR DESCRIPTION
- Add ENTER_DOCKING_MODE and EXIT_DOCKING_MODE calls around X/Y homing ( gcode-offset are removed from active tool while homing )
- Use position_endstop instead of position_max for rebound calculations

This has now been tested on a few different system. Tap and Scanner setup.