### PR TITLE
Add klipper support for commit 7f5e918

### DIFF
--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -134,7 +134,8 @@ class ProbeSessionHelper:
         # Allow axis_twist_compensation to update results
         self.printer.send_event("probe:update_results", epos)
         # Create ProbeResult
-        result = self.probe_offsets.create_probe_result(epos)
+        offsets = self.probe_offsets.get_offsets()
+        result = manual_probe.create_probe_result(epos, offsets)
         # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -134,8 +134,13 @@ class ProbeSessionHelper:
         # Allow axis_twist_compensation to update results
         self.printer.send_event("probe:update_results", epos)
         # Create ProbeResult
-        offsets = self.probe_offsets.get_offsets()
-        result = manual_probe.create_probe_result(epos, offsets)
+        if hasattr(manual_probe, 'create_probe_result'): 
+            # Klipper post 7f5e918
+            offsets = self.probe_offsets.get_offsets()
+            result = manual_probe.create_probe_result(epos, offsets)
+        else:
+            # Legacy
+            result = self.probe_offsets.create_probe_result(epos)
         # Report results
         gcode = self.printer.lookup_object('gcode')
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -14,6 +14,13 @@ class ToolProbeOffsetsHelper:
     def get_offsets(self, gcmd=None):
         return self.tool_probe_endstop.get_offsets(gcmd)
 
+    # Support legacy Klipper versions where HomingViaProbeHelper calls this
+    def create_probe_result(self, test_pos):
+        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
+        return manual_probe.ProbeResult(
+            test_pos[0]+x_offset, test_pos[1]+y_offset,
+            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
+
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
 # Or via auto-detection of single open tool probe via DETECT_ACTIVE_TOOL_PROBE

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -14,12 +14,6 @@ class ToolProbeOffsetsHelper:
     def get_offsets(self, gcmd=None):
         return self.tool_probe_endstop.get_offsets(gcmd)
 
-    def create_probe_result(self, test_pos):
-        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
-        return manual_probe.ProbeResult(
-            test_pos[0]+x_offset, test_pos[1]+y_offset,
-            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
-
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
 # Or via auto-detection of single open tool probe via DETECT_ACTIVE_TOOL_PROBE


### PR DESCRIPTION
Klipper broke KTC-easy with [this commit](https://github.com/Klipper3d/klipper/commit/7f5e918331dc1695899433915659337dc50176e0).

This PR resolves the issue while maintaining legacy support.