### PR TITLE
Add settable probing temperature

### DIFF
--- a/examples/easy-additions/toolchanger-macros.cfg
+++ b/examples/easy-additions/toolchanger-macros.cfg
@@ -1,17 +1,20 @@
 [gcode_macro _TAP_PROBE_ACTIVATE]
-description: Ensure safe temp for bed probing
+description: Ensure nozzle is at a reasonable temperature for bed probing
 gcode:
-    {% set max_temp = 150 %}
+    {% set temp = params.TEMP|default(150)|float %}
     {% set actual_temp = printer[params.HEATER].temperature %}
     {% set target_temp = printer[params.HEATER].target %}
-    {% if target_temp > max_temp %}
-        { action_respond_info('Extruder temperature target of %.1fC is too high, lowering to %.1fC' % (target_temp, max_temp)) }
-        SET_HEATER_TEMPERATURE HEATER={params.HEATER} TARGET={ max_temp|int - 5 }
-    {% endif %}
-    # Temperature target is already low enough, but nozzle may still be too hot.
-    {% if actual_temp > max_temp  + 2 %}
-        { action_respond_info('Extruder temperature %.1fC is still too high, waiting until below %.1fC' % (actual_temp, max_temp)) }
-        TEMPERATURE_WAIT SENSOR={params.HEATER} MAXIMUM={ max_temp }
+
+    # If the nozzle is too hot or set to a higher temperature than probe temp, lower to probe temp and wait to cool
+    {% if actual_temp > (temp + 2) or target_temp > temp %}
+        { action_respond_info('Extruder temperature %.1fC is too high, lowering to %.1fC and waiting' % (actual_temp, temp)) }
+        SET_HEATER_TEMPERATURE HEATER={params.HEATER} TARGET={temp|int}
+        TEMPERATURE_WAIT SENSOR={params.HEATER} MAXIMUM={temp}
+    # If the target is not set or below probe temp, heat up to probe temp and wait
+    {% elif target_temp < temp %}
+        { action_respond_info('Extruder temperature target %.1fC is below probe temp %.1fC, heating and waiting' % (target_temp, temp)) }
+        SET_HEATER_TEMPERATURE HEATER={params.HEATER} TARGET={temp|int}
+        TEMPERATURE_WAIT SENSOR={params.HEATER} MINIMUM={temp}
     {% endif %}
 
 [gcode_macro M104]

--- a/examples/easy-additions/user-configs/tools/tap_per_tool/example_T0.cfg
+++ b/examples/easy-additions/user-configs/tools/tap_per_tool/example_T0.cfg
@@ -99,4 +99,4 @@ sample_retract_dist: 2.0
 samples_tolerance: 0.02
 samples_tolerance_retries: 3
 activate_gcode:
-    _TAP_PROBE_ACTIVATE HEATER=extruder
+    _TAP_PROBE_ACTIVATE HEATER=extruder TEMP=150

--- a/examples/easy-additions/user-configs/tools/tap_per_tool/example_T1.cfg
+++ b/examples/easy-additions/user-configs/tools/tap_per_tool/example_T1.cfg
@@ -99,4 +99,4 @@ sample_retract_dist: 2.0
 samples_tolerance: 0.02
 samples_tolerance_retries: 3
 activate_gcode:
-    _TAP_PROBE_ACTIVATE HEATER=extruder1
+    _TAP_PROBE_ACTIVATE HEATER=extruder1 TEMP=150


### PR DESCRIPTION
Adds logic to also heat the nozzle to a suitable probing temperature if the temp is too low.

Default temperature is 150 and it can also be set in the user's activate_gcode for tool_probe.

```
activate_gcode:
    _TAP_PROBE_ACTIVATE HEATER=extruder TEMP=150
```

