### PR TITLE
tool_probe: update for latest Klipper probe API

### DIFF
--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -3,18 +3,19 @@
 # Copyright (C) 2023 Viesturs Zarins <viesturz@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
 from . import probe
-from . import manual_probe
 
 class ToolProbe:
     def __init__(self, config):
         self.tool = config.getint('tool')
         self.printer = config.get_printer()
         self.name = config.get_name()
-        self.mcu_probe = probe.ProbeEndstopWrapper(config)
         self.probe_offsets = probe.ProbeOffsetsHelper(config)
-        self.probe_session = ProbeSessionHelper(config, self.mcu_probe, self.probe_offsets)
+        self.param_helper = probe.ProbeParameterHelper(config)
+        self.mcu_probe = probe.ProbeEndstopWrapper(
+            config, self.probe_offsets, self.param_helper)
+        self.probe_session = probe.SampleAveragingHelper(
+            config, self.param_helper, self.mcu_probe.start_probe_session)
 
         # Crash detection stuff
         pin = config.get('pin')
@@ -31,154 +32,11 @@ class ToolProbe:
         self.endstop.note_probe_triggered(self, eventtime, is_triggered)
 
     def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
+        return self.param_helper.get_probe_params(gcmd)
     def get_offsets(self, gcmd=None):
         return self.probe_offsets.get_offsets(gcmd)
     def start_probe_session(self, gcmd):
         return self.probe_session.start_probe_session(gcmd)
-
-# Helper to track multiple probe attempts in a single command
-class ProbeSessionHelper:
-    def __init__(self, config, mcu_probe, probe_offsets):
-        self.printer = config.get_printer()
-        self.mcu_probe = mcu_probe
-        self.probe_offsets = probe_offsets
-        gcode = self.printer.lookup_object('gcode')
-        self.dummy_gcode_cmd = gcode.create_gcode_command("", "", {})
-        # Infer Z position to move to during a probe
-        if config.has_section('stepper_z'):
-            zconfig = config.getsection('stepper_z')
-            self.z_position = zconfig.getfloat('position_min', 0.,
-                                               note_valid=False)
-        else:
-            pconfig = config.getsection('printer')
-            self.z_position = pconfig.getfloat('minimum_z_position', 0.,
-                                               note_valid=False)
-        # Configurable probing speeds
-        self.speed = config.getfloat('speed', 5.0, above=0.)
-        self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)
-        # Multi-sample support (for improved accuracy)
-        self.sample_count = config.getint('samples', 1, minval=1)
-        self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
-                                                   above=0.)
-        atypes = {'median': 'median', 'average': 'average'}
-        self.samples_result = config.getchoice('samples_result', atypes,
-                                               'average')
-        self.samples_tolerance = config.getfloat('samples_tolerance', 0.100,
-                                                 minval=0.)
-        self.samples_retries = config.getint('samples_tolerance_retries', 0,
-                                             minval=0)
-        # Session state
-        self.multi_probe_pending = False
-        self.results = []
-        # Register event handlers
-        self.printer.register_event_handler("gcode:command_error",
-                                            self._handle_command_error)
-    def _handle_command_error(self):
-        if self.multi_probe_pending:
-            try:
-                self.end_probe_session()
-            except:
-                logging.exception("Multi-probe end")
-    def _probe_state_error(self):
-        raise self.printer.command_error(
-            "Internal probe error - start/end probe session mismatch")
-    def start_probe_session(self, gcmd):
-        if self.multi_probe_pending:
-            self._probe_state_error()
-        self.mcu_probe.multi_probe_begin()
-        self.multi_probe_pending = True
-        self.results = []
-        return self
-    def end_probe_session(self):
-        if not self.multi_probe_pending:
-            self._probe_state_error()
-        self.results = []
-        self.multi_probe_pending = False
-        self.mcu_probe.multi_probe_end()
-    def get_probe_params(self, gcmd=None):
-        if gcmd is None:
-            gcmd = self.dummy_gcode_cmd
-        probe_speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)
-        lift_speed = gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.)
-        samples = gcmd.get_int("SAMPLES", self.sample_count, minval=1)
-        sample_retract_dist = gcmd.get_float("SAMPLE_RETRACT_DIST",
-                                             self.sample_retract_dist, above=0.)
-        samples_tolerance = gcmd.get_float("SAMPLES_TOLERANCE",
-                                           self.samples_tolerance, minval=0.)
-        samples_retries = gcmd.get_int("SAMPLES_TOLERANCE_RETRIES",
-                                       self.samples_retries, minval=0)
-        samples_result = gcmd.get("SAMPLES_RESULT", self.samples_result)
-        return {'probe_speed': probe_speed,
-                'lift_speed': lift_speed,
-                'samples': samples,
-                'sample_retract_dist': sample_retract_dist,
-                'samples_tolerance': samples_tolerance,
-                'samples_tolerance_retries': samples_retries,
-                'samples_result': samples_result}
-    def _probe(self, speed):
-        toolhead = self.printer.lookup_object('toolhead')
-        curtime = self.printer.get_reactor().monotonic()
-        if 'z' not in toolhead.get_status(curtime)['homed_axes']:
-            raise self.printer.command_error("Must home before probe")
-        pos = toolhead.get_position()
-        pos[2] = self.z_position
-        try:
-            phoming = self.printer.lookup_object('homing')
-            epos = phoming.probing_move(self.mcu_probe, pos, speed)
-        except self.printer.command_error as e:
-            reason = str(e)
-            if "Timeout during endstop homing" in reason:
-                reason += probe.HINT_TIMEOUT
-            raise self.printer.command_error(reason)
-        # Allow axis_twist_compensation to update results
-        self.printer.send_event("probe:update_results", epos)
-        # Create ProbeResult
-        if hasattr(manual_probe, 'create_probe_result'): 
-            # Klipper post 7f5e918
-            offsets = self.probe_offsets.get_offsets()
-            result = manual_probe.create_probe_result(epos, offsets)
-        else:
-            # Legacy
-            result = self.probe_offsets.create_probe_result(epos)
-        # Report results
-        gcode = self.printer.lookup_object('gcode')
-        gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
-                           % (epos[0], epos[1], epos[2]))
-        return result
-    def run_probe(self, gcmd):
-        if not self.multi_probe_pending:
-            self._probe_state_error()
-        params = self.get_probe_params(gcmd)
-        toolhead = self.printer.lookup_object('toolhead')
-        probexy = toolhead.get_position()[:2]
-        retries = 0
-        positions = []
-        sample_count = params['samples']
-        while len(positions) < sample_count:
-            # Probe position
-            pos = self._probe(params['probe_speed'])
-            positions.append(pos)
-            # Check samples tolerance
-            z_positions = [p.bed_z for p in positions]
-            if max(z_positions)-min(z_positions) > params['samples_tolerance']:
-                if retries >= params['samples_tolerance_retries']:
-                    raise gcmd.error("Probe samples exceed samples_tolerance")
-                gcmd.respond_info("Probe samples exceed tolerance. Retrying...")
-                retries += 1
-                positions = []
-            # Retract
-            if len(positions) < sample_count:
-                toolhead.manual_move(
-                    probexy + [pos.bed_z + params['sample_retract_dist']],
-                    params['lift_speed'])
-        # Calculate result
-        epos = probe.calc_probe_z_average(positions, params['samples_result'])
-        self.results.append(epos)
-    def pull_probed_results(self):
-        res = self.results
-        self.results = []
-        return res
 
 def load_config_prefix(config):
     return ToolProbe(config)

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -4,22 +4,6 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from . import probe
-from . import manual_probe
-
-# Helper class to provide probe offsets interface for ToolProbeEndstop
-class ToolProbeOffsetsHelper:
-    def __init__(self, tool_probe_endstop):
-        self.tool_probe_endstop = tool_probe_endstop
-
-    def get_offsets(self, gcmd=None):
-        return self.tool_probe_endstop.get_offsets(gcmd)
-
-    # Support legacy Klipper versions where HomingViaProbeHelper calls this
-    def create_probe_result(self, test_pos):
-        x_offset, y_offset, z_offset = self.tool_probe_endstop.get_offsets()
-        return manual_probe.ProbeResult(
-            test_pos[0]+x_offset, test_pos[1]+y_offset,
-            test_pos[2]-z_offset, test_pos[0], test_pos[1], test_pos[2])
 
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
@@ -37,11 +21,14 @@ class ToolProbeEndstop:
         self.crash_detection_active = False
         self.crash_lasttime = 0.
         self.mcu_probe = EndstopRouter(self.printer)
-        self.probe_offsets = ToolProbeOffsetsHelper(self)
         self.param_helper = probe.ProbeParameterHelper(config)
-        self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe, self.probe_offsets, self.param_helper)
-        self.probe_session = probe.ProbeSessionHelper(config, self.param_helper, self.homing_helper.start_probe_session)
-        self.cmd_helper = probe.ProbeCommandHelper(config, self, self.mcu_probe.query_endstop)
+        self.cmd_helper = probe.ProbeCommandHelper(config, self,
+                                                   self.mcu_probe.query_endstop)
+        # Current Klipper only uses position_endstop to identify virtual
+        # probe homing. The active probe session supplies the actual offset.
+        probe.HomingViaProbeHelper(config, 0.0, self.mcu_probe.query_endstop)
+        self.probe_session = probe.SampleAveragingHelper(
+            config, self.param_helper, self.mcu_probe.start_probe_session)
 
         # Emulate the probe object, since others rely on this.
         if self.printer.lookup_object('probe', default=None):
@@ -71,12 +58,12 @@ class ToolProbeEndstop:
         if self.active_probe:
             return self.active_probe.get_offsets(gcmd)
         return 0.0, 0.0, 0.0
-    
+
     def get_probe_params(self, gcmd=None):
         if self.active_probe:
             return self.active_probe.get_probe_params(gcmd)
         raise self.printer.command_error("No active tool probe")
-    
+
     def start_probe_session(self, gcmd):
         if self.active_probe:
             return self.active_probe.start_probe_session(gcmd)
@@ -211,7 +198,6 @@ class ToolProbeEndstop:
 class EndstopRouter:
     def __init__(self, printer):
         self.active_mcu = None
-        self.set_active_mcu(None)
         self._mcus = []
         self._steppers = []
         self.printer = printer
@@ -223,23 +209,6 @@ class EndstopRouter:
 
     def set_active_mcu(self, mcu_probe):
         self.active_mcu = mcu_probe
-        # Update Wrappers
-        if self.active_mcu:
-            self.get_mcu = self.active_mcu.get_mcu
-            self.home_start = self.active_mcu.home_start
-            self.home_wait = self.active_mcu.home_wait
-            self.multi_probe_begin = self.active_mcu.multi_probe_begin
-            self.multi_probe_end = self.active_mcu.multi_probe_end
-            self.probe_prepare = self.active_mcu.probe_prepare
-            self.probe_finish = self.active_mcu.probe_finish
-        else:
-            self.get_mcu = self.on_error
-            self.home_start = self.on_error
-            self.home_wait = self.on_error
-            self.multi_probe_begin = self.on_error
-            self.multi_probe_end = self.on_error
-            self.probe_prepare = self.on_error
-            self.probe_finish = self.on_error
 
     def add_stepper(self, stepper):
         self._steppers.append(stepper)
@@ -248,18 +217,14 @@ class EndstopRouter:
     def get_steppers(self):
         return list(self._steppers)
 
-    def on_error(self, *args, **kwargs):
-        raise self.printer.command_error("Cannot interact with probe - no active tool probe.")
     def query_endstop(self, print_time):
         if not self.active_mcu:
             raise self.printer.command_error("Cannot query endstop - no active tool probe.")
         return self.active_mcu.query_endstop(print_time)
-    def get_position_endstop(self):
+    def start_probe_session(self, gcmd):
         if not self.active_mcu:
-            # This will get picked up by the endstop, and is static
-            # Report 0 and fix up in the homing sequence
-            return 0.0
-        return self.active_mcu.get_position_endstop()
+            raise self.printer.command_error("Cannot start probe session - no active tool probe.")
+        return self.active_mcu.start_probe_session(gcmd)
 
 def load_config(config):
     return ToolProbeEndstop(config)


### PR DESCRIPTION
## Summary

Updates the tool probe integration for recent Klipper probe API changes (post May 2026).

Recent Klipper versions significantly refactored the internal probe virtual-endstop and probe-session APIs. With current Klipper, klipper-toolchanger-easy fails during startup with:

```
__init__() takes from 3 to 4 positional arguments but 2 were given
```

### Changes

**tool_probe.py:**
- Pass `ProbeOffsetsHelper` and `ProbeParameterHelper` to `ProbeEndstopWrapper` (now requires 3 args instead of 1)
- Replace custom `ProbeSessionHelper` class with Klipper's built-in `SampleAveragingHelper` (preserves multi-sample averaging and tolerance checking)
- Delegate probe params to `ProbeParameterHelper` instead of custom implementation

**tool_probe_endstop.py:**
- Replace `ProbeSessionHelper` with `SampleAveragingHelper`
- Use standard `HomingViaProbeHelper(config, 0.0, query_endstop_cb)` to register `probe:z_virtual_endstop` (old 4-arg signature no longer exists)
- Remove obsolete `EndstopRouter` MCU-endstop proxy bindings (`home_start`, `home_wait`, `multi_probe_begin`, etc.) that current `ProbeEndstopWrapper` no longer exposes
- Remove `ToolProbeOffsetsHelper` class (no longer needed)
- Add `start_probe_session` to `EndstopRouter` (replaces `get_position_endstop`)

### Klipper API changes this addresses

| Old API | New API |
|---------|---------|
| `ProbeEndstopWrapper(config)` | `ProbeEndstopWrapper(config, probe_offsets, param_helper)` |
| `ProbeSessionHelper` | `SampleAveragingHelper` |
| `HomingViaProbeHelper(config, mcu_probe, offsets, param_helper)` | `HomingViaProbeHelper(config, position_endstop, query_endstop_cb)` |
| `ProbeEndstopWrapper.multi_probe_begin/end` | `ProbeEndstopWrapper.start_probe_session/run_probe/end_probe_session` |

### Testing

Tested on a Voron 2.4 toolchanger with Tap (2 tools, CAN bus) running Klipper `c707dd19` (latest as of June 2026). Klipper starts successfully with all tool probes detected.

Adapted from [viesturz/klipper-toolchanger PR #174](https://github.com/viesturz/klipper-toolchanger/pull/174).