### PR TITLE
Removes double offsets and unused macros from homing.cfg

### DIFF
--- a/examples/easy-additions/homing.cfg
+++ b/examples/easy-additions/homing.cfg
@@ -68,10 +68,6 @@ gcode:
       G90 ; absolute mode
       G0 X{( max_x / 2 ) + random_x} Y{( max_y / 2 ) + random_y} F12000
       G28 Z
-      
-      {% if uses_tool_probe %}
-        _ADJUST_Z_HOME_FOR_TOOL_OFFSET
-      {% endif %}
 
       G0 Z10 F1000
     {% endif %}
@@ -112,28 +108,3 @@ gcode:
   {% if config.stepper_driver ~ ' stepper_y1' in printer.configfile.settings %}
     SET_TMC_CURRENT STEPPER=stepper_y1 CURRENT={RUN_CURRENT_Y1}
   {% endif %}
-
-
-; Depending on the selected tool at the time of homing, the physical Z endstop position is offset.
-; This corrects for that using current tool offset.
-[gcode_macro _ADJUST_Z_HOME_FOR_TOOL_OFFSET]
-gcode:
-      G90 ; absolute mode
-      G0 Z10 F1000
-      {% set tool = printer.toolchanger.tool %}
-      {% if tool %}
-         {% set tool_z_offset = printer[tool].gcode_z_offset %}
-         {% set probe_z_offset = printer.tool_probe_endstop.active_tool_probe_z_offset %}
-         SET_KINEMATIC_POSITION Z={10.0+tool_z_offset|float+probe_z_offset|float}
-      {% endif %}
-
-[gcode_macro TOOL_BED_MESH_CALIBRATE]
-gcode:
-      {% set tool_z_offset = printer[printer.toolchanger.tool].gcode_z_offset %}
-      G90 ; absolute mode
-      G0 Z10 F1000
-      # Bed mesh knows about the probe offset, but not about the tool offset.
-      SET_KINEMATIC_POSITION Z={10.0-tool_z_offset|float}
-      BED_MESH_CALIBRATE
-      G0 Z10 F1000
-      SET_KINEMATIC_POSITION Z={10.0+tool_z_offset|float}


### PR DESCRIPTION
The `z_offset` and `gcode_z_offsets` are getting applied internally (I couldn't find where the `z_offset` was getting applied...but the fact that it is always 2x the value proves that it is).  Removed these pieces from the homing.cfg and also removed those macros that are no longer used. 