### PR TITLE
 Ported changes from upstream ktc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ primary_branch: main
 ```
 
 ## Changelog
+* 2026.8.23 - Ported upstream fixes from viesturz/klipper-toolchanger (through 2026.4.6):
+     - Fix `manual_rail` homing on current Klipper (`manual_home` argument change). This was broken.
+     - `rounded_path`: drop near-zero residual moves that collapsed lookahead junction velocity.
+     - Fix tool detection not always working at startup (`assign_tool` race).
+     - Add `tool.heater` to specify a heater separately from the extruder.
+     - Add `ADJUST_Z_AFTER_TOOL_NOZZLE_HOME`.
+     - Add opt-in `toolchanger.abort_on_tool_missing` / `tool_missing_delay`.
+     - Stop spamming "Multiple tools detected" on startup.
+     - Dock alignment examples now use `ENTER_DOCKING_MODE` / `EXIT_DOCKING_MODE`.
+
+     Not ported: upstream's `tool.tool_probe` auto-selection and the associated
+     `detection_pin` polarity inversion. Upstream's version of those files targets an
+     older Klipper probe API than this fork requires.
 * 2026.1.25 - Example script for camera tool alignment.
 * 2025.12.26 - **Breaking change** Stop using Gcode offset for tool offsets. Uses a dedicated gcode transform instead.
 * 2025.12.25 - Use Bezier curves for rounded paths.

--- a/examples/dock location/fixed/toolchanger.cfg
+++ b/examples/dock location/fixed/toolchanger.cfg
@@ -136,7 +136,7 @@ gcode:
 gcode:
     {% set tool = printer[printer.toolchanger.tool] %}
     SET_TOOL_PARAMETER PARAMETER='params_path_speed' VALUE=300
-    SET_GCODE_OFFSET X=0 Y=0 Z=0
+    ENTER_DOCKING_MODE
     G0 Y{tool.params_safe_y} F{tool.params_fast_speed}
     G0 X{tool.params_park_x} Z{tool.params_park_z}
     G0 Y{tool.params_park_y|float + 100.0}
@@ -148,8 +148,6 @@ gcode:
       # Check if Y is not too far, to very unrealistic tests.
       RESPOND TYPE=error MSG='Test aborted. Tool too far away from the dock.'
     {% else %}
-      INITIALIZE_TOOLCHANGER # Detect current tool
-      SET_GCODE_OFFSET X=0 Y=0 Z=0
       SET_TOOL_PARAMETER PARAMETER='params_park_x' VALUE={curpos[0]}
       SET_TOOL_PARAMETER PARAMETER='params_park_y' VALUE={curpos[1]}
       SET_TOOL_PARAMETER PARAMETER='params_park_z' VALUE={curpos[2]}
@@ -164,3 +162,4 @@ gcode:
     SAVE_TOOL_PARAMETER PARAMETER='params_park_z'
     RESET_TOOL_PARAMETER PARAMETER='params_path_speed'
     G0 Y{tool.params_safe_y} F{tool.params_fast_speed}
+    EXIT_DOCKING_MODE

--- a/examples/dock location/litfbar/toolchanger.cfg
+++ b/examples/dock location/litfbar/toolchanger.cfg
@@ -131,14 +131,13 @@ gcode:
 [gcode_macro TOOL_ALIGN_START]
 gcode:
     INITIALIZE_TOOLCHANGER # Detect current tool
-    BED_MESH_CLEAR
     _TOOL_ALIGN_START
 
 [gcode_macro _TOOL_ALIGN_START]
 gcode:
     {% set tool = printer[printer.toolchanger.tool] %}
     SET_TOOL_PARAMETER PARAMETER='params_path_speed' VALUE=300
-    SET_GCODE_OFFSET X=0 Y=0 Z=0
+    ENTER_DOCKING_MODE
     G0 Y{tool.params_safe_y} F{tool.params_fast_speed}
     G0 X{tool.params_park_x} Z{tool.params_bed_drop}
     LIFTBAR_MOVE Z={tool.params_park_liftbar_z}
@@ -153,8 +152,6 @@ gcode:
       # Check if Y is not too far, to very unrealistic tests.
       RESPOND TYPE=error MSG='Test aborted. Tool too far away from the dock.'
     {% else %}
-      INITIALIZE_TOOLCHANGER # Detect current tool
-      SET_GCODE_OFFSET X=0 Y=0 Z=0
       SET_TOOL_PARAMETER PARAMETER='params_park_x' VALUE={curpos[0]}
       SET_TOOL_PARAMETER PARAMETER='params_park_y' VALUE={curpos[1]}
       SET_TOOL_PARAMETER PARAMETER='params_park_liftbar_z' VALUE={lifbar_z}
@@ -170,4 +167,5 @@ gcode:
     SAVE_TOOL_PARAMETER PARAMETER='params_park_liftbar_z'
     RESET_TOOL_PARAMETER PARAMETER='params_path_speed'
     G0 Y{tool.params_safe_y} F{tool.params_fast_speed}
+    EXIT_DOCKING_MODE
     LIFTBAR_PARK_TOP

--- a/examples/z probe/cartographer_probe_on_shuttle/homing.cfg
+++ b/examples/z probe/cartographer_probe_on_shuttle/homing.cfg
@@ -90,15 +90,7 @@ gcode:
 [gcode_macro CARTOGRAPHER_TOUCH_WITH_TOOL_OFFSET]
 gcode:
   CARTOGRAPHER_TOUCH
-  _ADJUST_Z_POSITION_WITH_TOOL_OFFSET
-
-[gcode_macro _ADJUST_Z_POSITION_WITH_TOOL_OFFSET]
-gcode:
-  {% set tool_name = printer.toolchanger.tool %}
-  {% if tool_name %}
-    {% set offset = printer[tool_name].gcode_z_offset %}
-    SET_KINEMATIC_POSITION Z={printer.toolhead.position.z + offset}
-  {% endif %}
+  ADJUST_Z_AFTER_TOOL_NOZZLE_HOME
 
 [gcode_macro _SENSORLESS_HOME_X]
 variable_home_current: 0.5
@@ -115,3 +107,12 @@ gcode:
     G1 X-30 F1200
     # Set current during print
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={RUN_CURRENT_X}
+
+[gcode_macro _CALIBRATE_BED_BEFORE_PRINT]
+gcode:
+  M117 Calibrating z offset
+  CARTOGRAPHER_TOUCH_HOME
+  ADJUST_Z_AFTER_TOOL_NOZZLE_HOME
+
+  M117 Calibrating bed
+  BED_MESH_CALIBRATE ADAPTIVE=1

--- a/klipper/extras/manual_rail.py
+++ b/klipper/extras/manual_rail.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2019-2025  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import logging
 import stepper
 from . import force_move
 
@@ -93,13 +92,13 @@ class ManualRail:
         self.do_set_position(forcepos)
         endstops = self.rail.get_endstops()
         phoming = self.printer.lookup_object('homing')
-        phoming.manual_home(self, endstops, pos, hi.speed, True, True)
+        phoming.manual_home(self, endstops, pos, hi.speed, probe_pos=False, triggered=True, check_triggered=True)
         # Perform second home
         if hi.retract_dist:
             retract_dist = -hi.retract_dist if hi.positive_dir else hi.retract_dist
             self.do_move(hi.position_endstop + retract_dist, hi.speed, accel)
             self.do_set_position(hi.position_endstop + retract_dist * 1.5)
-            phoming.manual_home(self, endstops, pos, hi.second_homing_speed, True, True)
+            phoming.manual_home(self, endstops, pos, hi.second_homing_speed, probe_pos=False, triggered=True, check_triggered=True)
     cmd_MANUAL_RAIL_help = "Command a manually configured rail"
     def cmd_MANUAL_RAIL(self, gcmd):
         if gcmd.get('GCODE_AXIS', None) is not None:

--- a/klipper/extras/manual_rail.py
+++ b/klipper/extras/manual_rail.py
@@ -93,13 +93,13 @@ class ManualRail:
         self.do_set_position(forcepos)
         endstops = self.rail.get_endstops()
         phoming = self.printer.lookup_object('homing')
-        phoming.manual_home(self, endstops, pos, hi.speed, True, True)
+        phoming.manual_home(self, endstops, pos, hi.speed, False, True, True)
         # Perform second home
         if hi.retract_dist:
             retract_dist = -hi.retract_dist if hi.positive_dir else hi.retract_dist
             self.do_move(hi.position_endstop + retract_dist, hi.speed, accel)
             self.do_set_position(hi.position_endstop + retract_dist * 1.5)
-            phoming.manual_home(self, endstops, pos, hi.second_homing_speed, True, True)
+            phoming.manual_home(self, endstops, pos, hi.second_homing_speed, False, True, True)
     cmd_MANUAL_RAIL_help = "Command a manually configured rail"
     def cmd_MANUAL_RAIL(self, gcmd):
         if gcmd.get('GCODE_AXIS', None) is not None:

--- a/klipper/extras/rounded_path.py
+++ b/klipper/extras/rounded_path.py
@@ -14,7 +14,7 @@ from math import comb
 
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import math
-EPSILON = 0.001
+EPSILON = 1e-9
 EPSILON_ANGLE = 0.001
 
 class ControlPoint:
@@ -97,7 +97,7 @@ class RoundedPath:
         self.real_G0 = self.gcode_move.cmd_G1
         self.gcode.register_command("ROUNDED_G0", self.cmd_ROUNDED_G0)
         self.buffer = []
-        self.lastg0 = []
+        self.lastg0 = None
 
         if config.getboolean('replace_g0', False):
             self.gcode.register_command("G0", None)
@@ -241,6 +241,9 @@ class RoundedPath:
         self._g0p(p, p.vec)
 
     def _g0p(self, p: ControlPoint, vec: list):
+        # ignore extremely short residual misalignements that may collapse lookahead junction velocity on otherwise smooth paths.
+        if self.lastg0 is not None and _vdist(self.lastg0, vec) <= 0.001:
+            return
         self.G0_params["X"]=vec[0]
         self.G0_params["Y"]=vec[1]
         self.G0_params["Z"]=vec[2]

--- a/klipper/extras/tool.py
+++ b/klipper/extras/tool.py
@@ -36,6 +36,7 @@ class Tool:
         self.params = {**self.toolchanger.params, **toolchanger.get_params_dict(config)}
         self.original_params = {}
         self.extruder_name = self._config_get(config, 'extruder', None)
+        self.heater_name = self._config_get(config, 'heater', None)
         detect_pin_name = config.get('detection_pin', None)
         self.detect_state = toolchanger.DETECT_UNAVAILABLE
         if detect_pin_name:
@@ -43,6 +44,7 @@ class Tool:
             self.detect_state = toolchanger.DETECT_ABSENT
         self.extruder_stepper_name = self._config_get(config, 'extruder_stepper', None)
         self.extruder = None
+        self.heater = None
         self.extruder_stepper = None
         self.fan_name = self._config_get(config, 'fan', None)
         self.fan = None
@@ -51,6 +53,12 @@ class Tool:
         self.t_command_restore_axis = self._config_get(
             config, 't_command_restore_axis', 'XYZ')
         self.tool_number = config.getint('tool_number', -1, minval=0)
+        if self.tool_number >= 0:
+            # Register with the toolchanger during config parsing, so that a
+            # detection pin callback can never arrive before the tools dict is
+            # populated. The T<n> gcode is registered later, at connect, so that
+            # a [gcode_macro T<n>] defined after [tool T<n>] still wins.
+            self.assign_tool(self.tool_number, register_gcode=False)
 
         gcode = self.printer.lookup_object('gcode')
         gcode.register_mux_command("ASSIGN_TOOL", "TOOL", self.name,
@@ -76,6 +84,9 @@ class Tool:
         configfile = self.printer.lookup_object('configfile')
         configfile.set(self.name, name, self.params[name])
 
+    def __str__(self):
+        return self.name
+
     def _apply_param(self, name, value):
         if name == 'gcode_x_offset':
                 self.gcode_x_offset = float(value)
@@ -89,15 +100,20 @@ class Tool:
             self.extruder_name) if self.extruder_name else None
         self.extruder_stepper = self.printer.lookup_object(
             self.extruder_stepper_name) if self.extruder_stepper_name else None
+        if self.heater_name:
+            self.heater = self.printer.lookup_object(self.heater_name)
+        elif self.extruder:
+            self.heater = self.extruder.get_heater()
+            self.heater_name = self.extruder_name
         if self.fan_name:
             self.fan = self.printer.lookup_object(self.fan_name,
                       self.printer.lookup_object("fan_generic " + self.fan_name))
         if self.tool_number >= 0:
-            self.assign_tool(self.tool_number)
+            self.register_t_gcode(self.tool_number)
 
     def _handle_detect(self, eventtime, is_triggered):
         self.detect_state = toolchanger.DETECT_PRESENT if is_triggered else toolchanger.DETECT_ABSENT
-        self.toolchanger.note_detect_change(self)
+        self.toolchanger.note_detect_change(self, eventtime)
 
     def get_status(self, eventtime):
         return {**self.params,
@@ -105,6 +121,7 @@ class Tool:
                 'toolchanger': self.toolchanger.name,
                 'tool_number': self.tool_number,
                 'extruder': self.extruder_name,
+                'heater': self.heater_name,
                 'extruder_stepper': self.extruder_stepper_name,
                 'fan': self.fan_name,
                 'active': self.main_toolchanger.get_selected_tool() == self,
@@ -124,11 +141,12 @@ class Tool:
     def cmd_ASSIGN_TOOL(self, gcmd):
         self.assign_tool(gcmd.get_int('N', minval=0), replace = True)
 
-    def assign_tool(self, number, replace = False):
+    def assign_tool(self, number, replace = False, register_gcode = True):
         prev_number = self.tool_number
         self.tool_number = number
         self.main_toolchanger.assign_tool(self, number, prev_number, replace)
-        self.register_t_gcode(number)
+        if register_gcode:
+            self.register_t_gcode(number)
 
     def register_t_gcode(self, number):
         gcode = self.printer.lookup_object('gcode')

--- a/klipper/extras/toolchanger.py
+++ b/klipper/extras/toolchanger.py
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-import ast, bisect
+import ast, bisect, logging
 from unittest.mock import sentinel
 
 STATUS_UNINITALIZED = 'uninitialized'
@@ -23,6 +23,75 @@ DETECT_UNAVAILABLE = -1
 DETECT_ABSENT = 0
 DETECT_PRESENT = 1
 
+_FUTURE = 9999999999999999.
+
+class ToolInterval:
+    def __init__(self, start, tool):
+        self.start = start
+        self.tool = tool
+        self.end = _FUTURE
+
+class ToolMissingHelper:
+    def __init__(self, toolchanger, config):
+        self.printer = config.get_printer()
+        self.toolchanger = toolchanger
+        self.reactor = self.printer.get_reactor()
+        self.enabled = config.getboolean('abort_on_tool_missing', False)
+        self.wait_time = config.getfloat('tool_missing_delay', 2.0, above=0.)
+        # Keep a log of last 10 active intervals. Probably an overkill.
+        self.active_intervals = []
+        self.tool_lasttime = 0.
+        self.current_tool = None
+        self.printer.register_event_handler('klippy:connect',
+                                            self._handle_connect)
+
+    def _handle_connect(self):
+        self.toolhead = self.printer.lookup_object('toolhead')
+        self.sdcard = self.printer.lookup_object('virtual_sdcard')
+
+    def activate(self, tool):
+        if self.enabled:
+            self.toolhead.register_lookahead_callback(lambda t: self.activate_at_time(t, tool))
+    def deactivate(self):
+        if self.enabled:
+            self.toolhead.register_lookahead_callback(lambda t: self.deactivate_at_time(t))
+
+    def activate_at_time(self, time, tool):
+        if len(self.active_intervals) == 0 or self.active_intervals[-1].end <= time:
+            self.active_intervals.append(ToolInterval(time, tool))
+        if len(self.active_intervals) > 10:
+            del self.active_intervals[0]
+        self.tool_lasttime = time
+        self.reactor.register_callback(lambda _: self._tool_change_delayed(time, tool), time + self.wait_time)
+
+    def deactivate_at_time(self, time):
+        if len(self.active_intervals) > 0 and self.active_intervals[-1].end >= time:
+            self.active_intervals[-1].end = time
+        self.activate_lasttime = 0.
+
+    def note_tool_change(self, eventtime, current_tool):
+        logging.info(f"Tool change to {current_tool} - detected, waiting... ")
+        self.tool_lasttime = eventtime
+        self.current_tool = current_tool
+        self.reactor.register_callback(lambda _: self._tool_change_delayed(eventtime, current_tool),
+                                       eventtime + self.wait_time)
+
+    def find_interval_at(self, eventtime):
+        return next((i for i in self.active_intervals if i.start <= eventtime <= i.end), None)
+
+    def _tool_change_delayed(self, time, current_tool):
+        interval = self.find_interval_at(time)
+        if interval is None:
+            logging.info(f"Tool change to {current_tool}, no active tool requested, ignoring")
+        elif self.tool_lasttime != time:
+            logging.info(f"Tool change to {current_tool} ignored, changed again before timeout")
+        elif not self.sdcard.is_active():
+            logging.info(f"Tool change to {current_tool} ignored, not printing")
+        elif interval and interval.tool == current_tool:
+            logging.info(f"Tool change to {current_tool}, as expected")
+        else:
+            logging.error(f"Tool change to{current_tool} at {time} - mismatch after wait time, expected {interval}, erroring out!!!")
+            self.toolchanger.process_error(None, "Tool no longer attached.")
 
 class Toolchanger:
     def __init__(self, config):
@@ -53,6 +122,8 @@ class Toolchanger:
             config, 'before_change_gcode', '')
         self.default_after_change_gcode = self.gcode_macro.load_template(
             config, 'after_change_gcode', '')
+
+        self.tool_missing_helper = ToolMissingHelper(self, config)
 
         # Read all the fields that might be defined on toolchanger.
         # To avoid throwing config error when no tools configured.
@@ -120,6 +191,8 @@ class Toolchanger:
                                     self.cmd_SAVE_TOOL_PARAMETER)
         self.gcode.register_command("VERIFY_TOOL_DETECTED",
                                     self.cmd_VERIFY_TOOL_DETECTED)
+        self.gcode.register_command("ADJUST_Z_AFTER_TOOL_NOZZLE_HOME",
+                                    self.cmd_ADJUST_Z_AFTER_TOOL_NOZZLE_HOME)
         self.fan_switcher = None
         self.validate_tool_timer = None
 
@@ -138,11 +211,13 @@ class Toolchanger:
 
     def _handle_command_error(self):
         self.status = STATUS_UNINITALIZED
+        self.tool_missing_helper.deactivate()
         self.active_tool = None
         self.gcode_transform.tool = None
 
     def _handle_shutdown(self):
         self.status = STATUS_UNINITALIZED
+        self.tool_missing_helper.deactivate_at_time(_FUTURE)
         self.active_tool = None
         self.gcode_transform.tool = None
 
@@ -213,12 +288,12 @@ class Toolchanger:
         temp = gcmd.get_float('TARGET', 0.)
         wait = gcmd.get_int('WAIT', 0) == 1
         tool = self._get_tool_from_gcmd(gcmd)
-        if not tool.extruder:
+        if not tool.heater:
             raise gcmd.error(
-                "SET_TOOL_TEMPERATURE: No extruder specified for tool %s" % (
+                "SET_TOOL_TEMPERATURE: No extruder or heater specified for tool %s" % (
                     tool.name))
         heaters = self.printer.lookup_object('heaters')
-        heaters.set_temperature(tool.extruder.get_heater(), temp, wait)
+        heaters.set_temperature(tool.heater, temp, wait)
 
     def _get_tool_from_gcmd(self, gcmd):
         tool_name = gcmd.get('TOOL', None)
@@ -244,7 +319,7 @@ class Toolchanger:
                 'SELECT_TOOL_ERROR called while not selecting, doing nothing')
             return
         message = gcmd.get('MESSAGE', '')
-        self._process_error(gcmd.error, message)
+        self.process_error(gcmd.error, message)
 
     cmd_UNSELECT_TOOL_help = "Unselect active tool without selecting a new one"
     def cmd_UNSELECT_TOOL(self, gcmd):
@@ -261,6 +336,7 @@ class Toolchanger:
             raise gcmd.error(
                 "Cannot enter docking mode, toolchanger status is %s, reason: %s" % (self.status, self.error_message))
         self.status = STATUS_CHANGING
+        self.tool_missing_helper.deactivate()
         self._save_state("", None)
         self._set_toolchange_transform()
 
@@ -271,6 +347,7 @@ class Toolchanger:
 
         self._restore_state_and_transform(self.active_tool)
         self.status = STATUS_READY
+        self.tool_missing_helper.activate(self.active_tool)
 
     cmd_TEST_TOOL_DOCKING_help = "Unselect active tool and select it again"
     def cmd_TEST_TOOL_DOCKING(self, gcmd):
@@ -308,6 +385,7 @@ class Toolchanger:
         if should_run_initialize:
             if self.status == STATUS_INITIALIZING:
                 self.status = STATUS_READY
+                self.tool_missing_helper.activate(self.active_tool)
                 self.gcode.respond_info('%s initialized, active %s' %
                                         (self.name,
                                          self.active_tool.name if self.active_tool else None))
@@ -347,6 +425,7 @@ class Toolchanger:
             self.run_gcode('before_change_gcode', before_change_gcode, extra_context)
             self._set_toolchange_transform()
 
+            self.tool_missing_helper.deactivate()
             if self.active_tool:
                 self.run_gcode('tool.dropoff_gcode',
                                self.active_tool.dropoff_gcode, extra_context)
@@ -356,7 +435,13 @@ class Toolchanger:
                 self.run_gcode('tool.pickup_gcode',
                                tool.pickup_gcode, extra_context)
                 if self.has_detection and self.verify_tool_pickup:
+                    toolhead = self.printer.lookup_object('toolhead')
+                    reactor = self.printer.get_reactor()
+                    toolhead.wait_moves()
+                    # Wait some more to allow tool sensors to update
+                    reactor.pause(reactor.monotonic() + 0.2)
                     self.validate_detected_tool(tool, respond_info=gcmd.respond_info, raise_error=gcmd.error)
+                self.tool_missing_helper.activate(tool)
                 self.run_gcode('after_change_gcode',
                                tool.after_change_gcode, extra_context)
 
@@ -377,7 +462,7 @@ class Toolchanger:
                 self.current_change_id = -1
                 raise
 
-    def _process_error(self, raise_error, message):
+    def process_error(self, raise_error, message):
         self.status = STATUS_ERROR
         self.error_message = message
         is_inside_toolchange = self.current_change_id != -1
@@ -447,7 +532,7 @@ class Toolchanger:
     def get_selected_tool(self):
         return self.active_tool
 
-    def note_detect_change(self, tool):
+    def note_detect_change(self, tool, eventtime):
         detected = None
         detected_names = []
         for tool in self.tools.values():
@@ -455,9 +540,9 @@ class Toolchanger:
                 detected = tool
                 detected_names.append(tool.name)
         if len(detected_names) > 1:
-            self.gcode.respond_info("Multiple tools detected: %s" % (detected_names,))
             detected = None
         self.detected_tool = detected
+        self.tool_missing_helper.note_tool_change(eventtime, detected)
 
     def require_detected_tool(self, respond_info):
         if self.detected_tool is not None:
@@ -480,7 +565,7 @@ class Toolchanger:
             expected_name = expected.name if expected else "None"
             actual_name = actual.name if actual else "None"
             message = "Expected tool %s but active is %s" % (expected_name, actual_name)
-            self._process_error(raise_error, message)
+            self.process_error(raise_error, message)
 
     def cmd_VERIFY_TOOL_DETECTED(self, gcmd):
         self._ensure_toolchanger_ready(gcmd)
@@ -612,6 +697,21 @@ class Toolchanger:
             raise gcmd.error('Tool does not have parameter %s' % (name))
         tool.save_parameter(name)
 
+    def cmd_ADJUST_Z_AFTER_TOOL_NOZZLE_HOME(self, gcmd):
+        tool = self.active_tool
+        if not tool:
+            raise gcmd.error("ADJUST_Z_AFTER_TOOL_NOZZLE_HOME - no active tool")
+        self._adjust_z_position_for_tool(tool)
+
+    def _adjust_z_position_for_tool(self, tool):
+        z_offset = tool.gcode_z_offset
+        if z_offset != 0.0:
+            logging.info(f"Toolchanger: Adjusting Z position after homing move by {z_offset}")
+            toolhead = self.printer.lookup_object('toolhead')
+            pos = list(toolhead.get_position())
+            pos[2] += z_offset
+            toolhead.set_position(pos)
+
     def ensure_homed(self, gcmd):
         if not self.uses_axis:
             return
@@ -665,7 +765,7 @@ class Toolchanger:
         if tool_number is not None:
             tool = self.lookup_tool(tool_number)
             if not tool:
-                raise gcmd.error('Tool #%d is not assigned' % (tool_number))
+                raise gcmd.error(f"Tool #{tool_number} is not assigned")
         if tool is None:
             if default == sentinel:
                 raise gcmd.error('Missing TOOL=<name> or T=<number>')
@@ -674,7 +774,7 @@ class Toolchanger:
 
     def _ensure_toolchanger_ready(self, gcmd):
         if self.status not in [STATUS_READY, STATUS_CHANGING]:
-            raise gcmd.error("VERIFY_TOOL_DETECTED: toolchanger not ready: status = %s", (self.status,))
+            raise gcmd.error(f"VERIFY_TOOL_DETECTED: toolchanger not ready: status = {self.status}")
 
 class FanSwitcher:
     def __init__(self, toolchanger, config):

--- a/toolchanger.md
+++ b/toolchanger.md
@@ -123,6 +123,8 @@ All gcode macros below have the following context available:
 # extruder:
   # Name of the extruder to activate when this tool is selected.
   # If not specified, will use parent's extruder.
+# heater:
+  # Name of the heater to use, will override extuder's heater when specificed.  
 # extruder_stepper: 
   # Name of extruder stepper to use for filament motion.
   # When set the main extruder is only used for temperature control.
@@ -165,6 +167,11 @@ All gcode macros below have the following context available:
   #  params_retract_mm: 8 
 # t_command_restore_axis: XYZ
    # Which axis to restore with the T<n> command, see SELECT_TOOL for command for more info.
+# abort_on_tool_missing: False
+  # Detects if tool goes missing during a print and calls `toolchanger.error_gcode`.
+  # Requires tools to have a `detection_pin` configured.
+# tool_missing_delay: 2.0
+  # Delay in seconds before triggering the tool missing logic. 
 ```
 
 # Gcodes
@@ -233,6 +240,10 @@ If ASYNC=1, will return immediately and perform the check in background after al
 A verification failure will:
  - abort in-progress toolchange, put the toolchanger in `ERROR` state.
  - Run`error_gcode` if one is provided. 
+
+### ADJUST_Z_AFTER_TOOL_NOZZLE_HOME
+`ADJUST_Z_AFTER_TOOL_NOZZLE_HOME`: Adjust toolhead Z position after bed probing to account for tool Z offset.
+Klipper's probing code ignores gcode transforms, so this has to be applied manually after a nozzle-based Z home.
 
 ### SET_TOOL_TEMPERATURE
 `SET_TOOL_TEMPERATURE [TOOL=<name>] [T=<number>]  TARGET=<temp> [WAIT=0]`: Set tool temperature.


### PR DESCRIPTION
- Fix manual_rail homing on current Klipper (manual_home argument change). This was broken.https://github.com/jwellman80/klipper-toolchanger-easy/commit/c665cd6e301adcf069355175cb4566b5d3e14234
- rounded_path: drop near-zero residual moves that collapsed lookahead junction velocity.https://github.com/jwellman80/klipper-toolchanger-easy/commit/0a3e1bf1bdd85ac0d1b1bc4e5d41e42a9db3a81b
- Fix tool detection not always working at startup (assign_tool race).https://github.com/jwellman80/klipper-toolchanger-easy/commit/1e273ab4b013b7896d5561d58b043d62972ef3de
- Add tool.heater to specify a heater separately from the extruder.https://github.com/jwellman80/klipper-toolchanger-easy/commit/f352ab499cd5ff2c8d2b2d15e7c8be885c1c4b2e
- Add ADJUST_Z_AFTER_TOOL_NOZZLE_HOME.https://github.com/jwellman80/klipper-toolchanger-easy/commit/e8dbbdf3be72f2ee1367389c8e0740304aac6ea2
- Add opt-in toolchanger.abort_on_tool_missing / tool_missing_delay.https://github.com/jwellman80/klipper-toolchanger-easy/commit/a5d43ef3379b7eeded6bac6991b5fae735adb493
- Stop spamming "Multiple tools detected" on startup.https://github.com/jwellman80/klipper-toolchanger-easy/commit/2ca8322d85ae06e233e826bbe2f983639b36ce1d
- Dock alignment examples now use ENTER_DOCKING_MODE / EXIT_DOCKING_MODE. https://github.com/jwellman80/klipper-toolchanger-easy/commit/eec18ece5f6b3a4f7592f1b2febea6aaaec5025f
- Fix abort_on_tool_missing mis-firing if there are waits during tool change.https://github.com/jwellman80/klipper-toolchanger-easy/commit/94756dfde9b729fd69f9b8780067821c5c99a528